### PR TITLE
fix default value of -1 for limit

### DIFF
--- a/includes/functions/achievements.php
+++ b/includes/functions/achievements.php
@@ -829,7 +829,7 @@ function gamipress_get_achievement_earners( $achievement_id = 0, $args = array()
     $args = wp_parse_args( $args, $defaults );
 
     // Setup limit
-    if( absint( $args['limit'] ) > 0 ) {
+    if( (int)( $args['limit'] ) > 0 ) {
         $limit = '0, ' . $args['limit'];
     }
 


### PR DESCRIPTION
giving no limit for gamipress_get_achievement_earners
led to a SQL error as the limit was to to LIMIT 0,-1
which is no valid SQL