### PR TITLE
center gamipress-rank-title for layout-top

### DIFF
--- a/assets/css/gamipress.css
+++ b/assets/css/gamipress.css
@@ -218,6 +218,7 @@
 }
 
 .gamipress-user-points.gamipress-layout-top .gamipress-points,
+.gamipress-user-points.gamipress-layout-top .gamipress-rank-title,
 .gamipress-user-points.gamipress-layout-bottom .gamipress-points {
 	text-align: center;
 }


### PR DESCRIPTION
added  center gamipress-rank-title when gamipress-layout-top